### PR TITLE
Update docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,28 +46,32 @@ It will generate the following outputs:
 
 ## Docker
 
-The file `docker/dockerfile` can be used to create a container that can run bloodstream either interactively in a Jupyter notebook or directly in a terminal (many thanks to @pwighton for this addition!).
+The file `docker/Dockerfile` can be used to create a container that can run bloodstream.
 
 To build the container, run: 
 
 ```
 cd docker
-docker build -t bloodstream:ubuntu-22.04 .
+docker build -t bloodstream . --platform linux/amd64
 ```
 
-The container derives from [`jupyter/r-notebook:ubuntu-22.04`](https://hub.docker.com/r/jupyter/r-notebook) (parent dockerfile lives [here](https://raw.githubusercontent.com/jupyter/docker-stacks/main/images/r-notebook/Dockerfile)) and can be invoked using:
+To run the bloodstream analysis using the Docker container, you need to mount the directory containing your BIDS dataset. In your BIDS data, you should also create a directory named `code/bloodstream` and add the files `docker/config.json` and `docker/run_bloodstream.R`. The `docker/config.json` is the config file used to run bloodstream obtained from https://mathesong.shinyapps.io/bloodstream_config/. 
 
 ```
-docker run -it --rm \
-  -p 8888:8888  \
-  -v ${HOME}:/home/jovyan/work \
-  bloodstream:ubuntu-22.04
+docker run -v /path/bids_data:/data/ bloodstream
 ```
 
-Then navigate to http://127.0.0.1:8888 (Look in the terminal output for the URL with the session token)
+All outputs from the bloodstream analysis will be located in the `derivatives` directory in the BIDS directory. 
 
-At some point in the future, the docker functionality will be expanded to include a non-interactive mode as well as a fully dockerised BIDS App.  But for now, this approach allows users to run `bloodstream` without needing to install R.
+## Docker example
 
+If your BIDS dataset is located at `/Users/mn/my_study`. Then you create the directories `/Users/mn/my_study/code/bloodstream` and add the `config.json` and `run_bloodstream.R` to this directory. After that you can run 
+
+```
+docker run -v /Users/mn/mystudy:/data/ bloodstream
+```
+
+and all your outputs will be in `/Users/mn/my_study/derivatives/bloodstream`.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd docker
 docker build -t bloodstream . --platform linux/amd64
 ```
 
-To run the bloodstream analysis using the Docker container, you need to mount the directory containing your BIDS dataset. In your BIDS data, you should also create a directory named `code/bloodstream` and add the files `docker/config.json` and `docker/run_bloodstream.R`. The `docker/config.json` is the config file used to run bloodstream obtained from https://mathesong.shinyapps.io/bloodstream_config/. 
+To run the bloodstream analysis using the Docker container, you need to mount the directory containing your BIDS dataset. In your BIDS data, you should also create a directory named `code/bloodstream` and add the file `config.json` obtained from https://mathesong.shinyapps.io/bloodstream_config/ (please note that the config file needs to be named `config.json`)
 
 ```
 docker run -v /path/bids_data:/data/ bloodstream
@@ -65,7 +65,7 @@ All outputs from the bloodstream analysis will be located in the `derivatives` d
 
 ## Docker example
 
-If your BIDS dataset is located at `/Users/mn/my_study`. Then you create the directories `/Users/mn/my_study/code/bloodstream` and add the `config.json` and `run_bloodstream.R` to this directory. After that you can run 
+If your BIDS dataset is located at `/Users/mn/my_study`. Then you create the directories `/Users/mn/my_study/code/bloodstream` and add the `config.json` to this directory. After that you can run 
 
 ```
 docker run -v /Users/mn/mystudy:/data/ bloodstream

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,0 +1,49 @@
+{
+  "Subsets": {
+    "sub": [""],
+    "ses": [""],
+    "rec": [""],
+    "task": [""],
+    "run": [""],
+    "TracerName": [""],
+    "ModeOfAdministration": [""],
+    "InstitutionName": [""],
+    "PharmaceuticalName": [""]
+  },
+  "Model": {
+    "ParentFraction": {
+      "Method": ["Fit Individually: Choose the best-fitting model"],
+      "set_ppf0": [true],
+      "starttime": [0.01],
+      "endtime": ["Inf"],
+      "gam_k": ["6"],
+      "hgam_formula": [""]
+    },
+    "BPR": {
+      "Method": ["Fit Hierarchically: HGAM"],
+      "starttime": [0.01],
+      "endtime": ["Inf"],
+      "gam_k": [6],
+      "hgam_formula": ["s(time, k=6) + s(time, ses, bs='fs', k=5)"]
+    },
+    "AIF": {
+      "Method": ["Fit Individually: Linear Rise, Triexponential Decay"],
+      "starttime": [0.01],
+      "endtime": [90],
+      "expdecay_props": ["NA", "NA"],
+      "inftime": ["NA"],
+      "spline_kb": [""],
+      "spline_ka_m": [""],
+      "spline_ka_a": [""]
+    },
+    "WholeBlood": {
+      "Method": ["Interpolation"],
+      "dispcor": [false],
+      "starttime": [0],
+      "endtime": ["Inf"],
+      "spline_kb": [""],
+      "spline_ka_m": [""],
+      "spline_ka_a": [""]
+    }
+  }
+}

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,16 +1,15 @@
-# Base container lives at 
-#   - https://raw.githubusercontent.com/jupyter/docker-stacks/main/images/r-notebook/Dockerfile
+# Use an R base image from Docker Hub
+FROM rocker/tidyverse:latest
 
-FROM jupyter/r-notebook:ubuntu-22.04
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev
 
-USER root
+# Install R packages
+RUN R -e "install.packages('devtools', repos = 'http://cran.rstudio.com/')"
+RUN R -e "remotes::install_github('mathesong/bloodstream', FORCE = TRUE)"
 
-RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends \
-      cmake && \
-    R -e 'remotes::install_github("mathesong/kinfitr")' && \
-    R -e 'remotes::install_github("mathesong/bloodstream")' && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-USER ${NB_UID}
+# Command to run your R script
+CMD ["Rscript", "/data/code/bloodstream/run_bloodstream.R", "config.json"]

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -11,5 +11,8 @@ RUN apt-get update && apt-get install -y \
 RUN R -e "install.packages('devtools', repos = 'http://cran.rstudio.com/')"
 RUN R -e "remotes::install_github('mathesong/bloodstream', FORCE = TRUE)"
 
+# Create the R script
+RUN printf "# run_bloodstream.R\nbids_dir <- file.path('/data')\nconfig_file <- file.path(bids_dir, 'code/bloodstream', 'config.json')\n\n# Load necessary libraries\nlibrary(bloodstream)\n\n# Execute bloodstream\nbloodstream(bids_dir, config_file)" > run_bloodstream.R
+
 # Command to run your R script
-CMD ["Rscript", "/data/code/bloodstream/run_bloodstream.R", "config.json"]
+CMD ["Rscript", "run_bloodstream.R", "/data/code/bloodstream/config.json"]

--- a/docker/run_bloodstream.R
+++ b/docker/run_bloodstream.R
@@ -1,0 +1,9 @@
+# run_bloodstream.R
+bids_dir <- file.path('/data')
+config_file <- file.path(bids_dir, 'code/bloodstream', 'config.json')
+
+# Load necessary libraries
+library(bloodstream)
+
+# Execute bloodstream
+bloodstream(bids_dir, config_file)


### PR DESCRIPTION
This PR suggests an alternative way to run bloodstream in a docker container. It simplifies the execution by asking the user to create a single config.json file and add it to the /path/bids/code/bloodstream, including an extra R analysis script (run_bloodstream.R) that also should be added to this path. After this, bloodstream can easily be run using docker. 

Documentation has also been updated to match the workflow, and one is (for now) supposed to build the docker container themselves. In the future, this should ideally be pushed to docker hub. 