### PR TITLE
ENH: update readme to include apptainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,44 @@ docker run -v /Users/mn/mystudy:/data/ bloodstream
 and all your outputs will be in `/Users/mn/my_study/derivatives/bloodstream`.
 -->
 
+## Apptainer
 
+`bloodstream` can also be run using [Apptainer](https://apptainer.org/) (formerly Singularity), which is often preferred on HPC (high-performance computing) systems.  
+The Apptainer image can be built directly from the existing Docker image, or downloaded and used as-is.
+
+### Build or pull the image
+
+To build the container from Docker Hub and save it as a local `.sif` file:
+
+```bash
+apptainer build bloodstream.sif docker://mathesong/bloodstream:latest
+```
+
+### Running bloodstream (no config file)
+To run bloodstream using Apptainer, bind your BIDS dataset to /data inside the container:
+
+```bash
+mkdir  -p ./workdir_host
+apptainer run \
+  -B /path/to/bids_data:/data \
+  -B "$(pwd)/workdir_host":/workdir \
+  bloodstream.sif
+```
+
+If no configuration file is provided, bloodstream will default to using linear interpolation only.
+
+All outputs from the analysis will be stored in /path/to/bids_data/derivatives/.
+
+### Running with a configuration file
+
+```bash
+mkdir  -p ./workdir_host
+apptainer run \
+  -B /path/to/bids_data:/data \
+  -B "$(pwd)/workdir_host":/workdir \
+  bloodstream.sif \
+  config_pf_bpr.json
+```
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -103,29 +103,38 @@ apptainer build bloodstream.sif docker://mathesong/bloodstream:latest
 ```
 
 ### Running bloodstream (no config file)
-To run bloodstream using Apptainer, bind your BIDS dataset to /data inside the container:
+
+Bind your BIDS dataset and a writable derivatives directory to the container. If no configuration file is provided, bloodstream will default to using linear interpolation only.
 
 ```bash
-mkdir  -p ./workdir_host
 apptainer run \
-  -B /path/to/bids_data:/data \
-  -B "$(pwd)/workdir_host":/workdir \
+  -B /path/to/bids:/data/bids_dir:ro \
+  -B /path/to/derivatives:/data/derivatives_dir:rw \
   bloodstream.sif
 ```
 
-If no configuration file is provided, bloodstream will default to using linear interpolation only.
-
-All outputs from the analysis will be stored in /path/to/bids_data/derivatives/.
+All outputs will be stored in `/path/to/derivatives/bloodstream/Primary_Analysis/`.
 
 ### Running with a configuration file
 
+To run with model fitting, bind a configuration file to `/config.json`:
+
 ```bash
-mkdir  -p ./workdir_host
 apptainer run \
-  -B /path/to/bids_data:/data \
-  -B "$(pwd)/workdir_host":/workdir \
-  bloodstream.sif \
-  config_pf_bpr.json
+  -B /path/to/bids:/data/bids_dir:ro \
+  -B /path/to/derivatives:/data/derivatives_dir:rw \
+  -B /path/to/config.json:/config.json:ro \
+  bloodstream.sif
+```
+
+### Custom analysis folder name
+
+```bash
+apptainer run \
+  -B /path/to/bids:/data/bids_dir:ro \
+  -B /path/to/derivatives:/data/derivatives_dir:rw \
+  -B /path/to/config.json:/config.json:ro \
+  bloodstream.sif --analysis_foldername "my_analysis"
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Bind your BIDS dataset and a writable derivatives directory to the container. If
 
 ```bash
 apptainer run \
-  -B /path/to/bids:/data/bids_dir:ro \
-  -B /path/to/derivatives:/data/derivatives_dir:rw \
+  --bind /path/to/bids:/data/bids_dir:ro \
+  --bind /path/to/derivatives:/data/derivatives_dir:rw \
   bloodstream.sif
 ```
 
@@ -121,9 +121,9 @@ To run with model fitting, bind a configuration file to `/config.json`:
 
 ```bash
 apptainer run \
-  -B /path/to/bids:/data/bids_dir:ro \
-  -B /path/to/derivatives:/data/derivatives_dir:rw \
-  -B /path/to/config.json:/config.json:ro \
+  --bind /path/to/bids:/data/bids_dir:ro \
+  --bind /path/to/derivatives:/data/derivatives_dir:rw \
+  --bind /path/to/config.json:/config.json:ro \
   bloodstream.sif
 ```
 
@@ -131,9 +131,9 @@ apptainer run \
 
 ```bash
 apptainer run \
-  -B /path/to/bids:/data/bids_dir:ro \
-  -B /path/to/derivatives:/data/derivatives_dir:rw \
-  -B /path/to/config.json:/config.json:ro \
+  --bind /path/to/bids:/data/bids_dir:ro \
+  --bind /path/to/derivatives:/data/derivatives_dir:rw \
+  --bind /path/to/config.json:/config.json:ro \
   bloodstream.sif --analysis_foldername "my_analysis"
 ```
 


### PR DESCRIPTION
This PR adresses issue #20 by including apptainer documentation. bloodstream requires a temporary directory inside the container, and since apptainer is not executed with root privileges similar to docker, one needs to mount a temporary directory into the apptainer container.